### PR TITLE
Correct 'How to install' link on README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Watch Anna in action on [Youtube](https://www.youtube.com/watch?v=17bVrAZMgEY):
 
 - [What all can Anna do?](https://github.com/Anna-Assistant/Anna/blob/master/docs/HowItWorks.md)
 - [How to Add new features?](https://github.com/Anna-Assistant/Anna/blob/master/docs/AdditionOfNewFeatures.md)
-- [How to install?](https://github.com/Anna-Assistant/Anna/blob/master/docs/ArrangementOfFiles.md)
+- [How to install?](https://github.com/Anna-Assistant/Anna/blob/master/docs/HowToInstallGuide.md)
 - [How are files arranged?](https://github.com/Anna-Assistant/Anna/blob/master/docs/ArrangementOfFiles.md)
 
 


### PR DESCRIPTION
Currently **How To Install** link takes us to wrong page. This PR fixes the link associated with this.