### PR TITLE
Add lyrics intent

### DIFF
--- a/background.js
+++ b/background.js
@@ -370,6 +370,10 @@ $(document).ready(function() {
                   chrome.tabs.create({
                       'url': "https://www.google.com/maps/?q=" + data.result.parameters.any
                   });
+              } else if (data.result.metadata.intentName === "lyrics") {
+                  chrome.tabs.create({
+                      'url': "https://www.google.com/search?q=lyrics+for+" + data.result.parameters.any + "&btnI"
+                  });
               } else if (data.result.metadata.intentName == "weather") {
                   weather(data.result.parameters.any);
               } else if (data.result.metadata.intentName == "screenshot") {


### PR DESCRIPTION
This uses a Google search with "I'm Feeling Lucky". The query is "lyrics for" & whatever parameters. It's a... hacky solution, but I suppose it'd work. There might be security concerns though.

![lyrics](https://user-images.githubusercontent.com/38927017/41322707-0b7ecac4-6e70-11e8-98c6-0f49aeaa6c17.png)

Example:
 - User asks for the lyrics of (song) (Example: "Hey, lyrics for (song)")
 - New tab opens up to "https://www.google.com/search?q=lyrics+for+(song)&btnI"
 - Google redirects to the top result for that query. In the case of "lyrics for Clocks" it goes to [https://www.azlyrics.com/lyrics/coldplay/clocks.html](https://www.azlyrics.com/lyrics/coldplay/clocks.html), as that is the top result.


