### PR TITLE
Fix typo in download badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 ![alt-image](https://github.com/Anna-Assistant/Anna/blob/master/img/Tile%20Image(1400x560).png)
 
 [![Zulip Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://anna.zulipchat.com/)
-[![Download From Chrome-Webstore](https://img.shields.io/badge/download-chrome--westore-brightgreen.svg)](https://chrome.google.com/webstore/detail/anna-assistant/kmkkgdkinnjokklbfloikdbdohbiklog)
+[![Download From Chrome-Webstore](https://img.shields.io/badge/download-chrome--webstore-brightgreen.svg)](https://chrome.google.com/webstore/detail/anna-assistant/kmkkgdkinnjokklbfloikdbdohbiklog)
 [![HitCount](http://hits.dwyl.io/gauthamzz/Anna-Assistant/Anna.svg)](http://hits.dwyl.io/gauthamzz/Anna-Assistant/Anna)
 [![Code Helpers Badge](https://www.codetriage.com/anna-assistant/anna/badges/users.svg)](https://www.codetriage.com/anna-assistant/anna)
 


### PR DESCRIPTION
 changed chrome-westore (left download badge) to chrome-webstore (right download badge)

![image](https://user-images.githubusercontent.com/18064158/49572669-46848000-f962-11e8-8623-9b5ea7dfe963.png)



